### PR TITLE
refactors namings in constants and fhir profiles

### DIFF
--- a/dsf-bpe-process-hello-world/src/main/java/org/highmed/dsf/bpe/ConstantsHelloWorld.java
+++ b/dsf-bpe-process-hello-world/src/main/java/org/highmed/dsf/bpe/ConstantsHelloWorld.java
@@ -1,12 +1,13 @@
 package org.highmed.dsf.bpe;
 
-import static org.highmed.dsf.bpe.ConstantsBase.PROCESS_URI_BASE;
+import static org.highmed.dsf.bpe.ConstantsBase.PROCESS_HIGHMED_URI_BASE;
 import static org.highmed.dsf.bpe.HelloWorldProcessPluginDefinition.VERSION;
 
 public interface ConstantsHelloWorld
 {
-	String HELLO_WORLD_TASK_PROFILE = "http://highmed.org/fhir/StructureDefinition/highmed-task-hello-world";
-	String HELLO_WORLD_PROCESS_URI = PROCESS_URI_BASE + "helloWorld/";
-	String HELLO_WORLD_PROCESS_URI_AND_LATEST_VERSION = HELLO_WORLD_PROCESS_URI + VERSION;
-	String HELLO_WORLD_MESSAGE_NAME = "helloWorldMessage";
+	String PROFILE_HIGHMED_TASK_HELLO_WORLD = "http://highmed.org/fhir/StructureDefinition/task-hello-world";
+	String PROFILE_HIGHMED_TASK_HELLO_WORLD_PROCESS_URI = PROCESS_HIGHMED_URI_BASE + "helloWorld/";
+	String PROFILE_HIGHMED_TASK_HELLO_WORLD_PROCESS_URI_AND_LATEST_VERSION =
+			PROFILE_HIGHMED_TASK_HELLO_WORLD_PROCESS_URI + VERSION;
+	String PROFILE_HIGHMED_TASK_HELLO_WORLD_MESSAGE_NAME = "helloWorldMessage";
 }

--- a/dsf-bpe-process-hello-world/src/main/java/org/highmed/dsf/bpe/HelloWorldProcessPluginDefinition.java
+++ b/dsf-bpe-process-hello-world/src/main/java/org/highmed/dsf/bpe/HelloWorldProcessPluginDefinition.java
@@ -44,7 +44,7 @@ public class HelloWorldProcessPluginDefinition implements ProcessPluginDefinitio
 	@Override
 	public ResourceProvider getResourceProvider(FhirContext fhirContext, ClassLoader classLoader)
 	{
-		var aHelloWorld = ActivityDefinitionResource.file("fhir/ActivityDefinition/helloWorld.xml");
+		var aHelloWorld = ActivityDefinitionResource.file("fhir/ActivityDefinition/highmed-helloWorld.xml");
 		var tHelloWorld = StructureDefinitionResource.file("fhir/StructureDefinition/highmed-task-hello-world.xml");
 
 		Map<String, List<AbstractResource>> resourcesByProcessKeyAndVersion = Map

--- a/dsf-bpe-process-hello-world/src/main/java/org/highmed/dsf/bpe/service/HelloWorld.java
+++ b/dsf-bpe-process-hello-world/src/main/java/org/highmed/dsf/bpe/service/HelloWorld.java
@@ -21,6 +21,6 @@ public class HelloWorld extends AbstractServiceDelegate
 	public void doExecute(DelegateExecution execution) throws Exception
 	{
 		Task task = getCurrentTaskFromExecutionVariables();
-		logger.info("Hello World from organization {}", task.getRequester().getIdentifier().getValue());
+		logger.info("Hello World from organization with identifier '{}'", task.getRequester().getIdentifier().getValue());
 	}
 }

--- a/dsf-bpe-process-hello-world/src/main/resources/fhir/ActivityDefinition/highmed-helloWorld.xml
+++ b/dsf-bpe-process-hello-world/src/main/resources/fhir/ActivityDefinition/highmed-helloWorld.xml
@@ -5,7 +5,7 @@
 			<code value="REMOTE" />
 		</tag>
 	</meta>
-	<extension url="http://highmed.org/fhir/StructureDefinition/process-authorization">
+	<extension url="http://highmed.org/fhir/StructureDefinition/extension-process-authorization">
 		<extension url="message-name">
 			<valueString value="helloWorldMessage" />
 		</extension>
@@ -46,7 +46,7 @@
 			</extension>
 		</extension>
 		<extension url="task-profile">
-			<valueCanonical value="http://highmed.org/fhir/StructureDefinition/highmed-task-hello-world" />
+			<valueCanonical value="http://highmed.org/fhir/StructureDefinition/task-hello-world" />
 		</extension>
 	</extension>
 	<url value="http://highmed.org/bpe/Process/helloWorld" />

--- a/dsf-bpe-process-hello-world/src/main/resources/fhir/StructureDefinition/highmed-task-hello-world.xml
+++ b/dsf-bpe-process-hello-world/src/main/resources/fhir/StructureDefinition/highmed-task-hello-world.xml
@@ -5,7 +5,7 @@
       <code value="REMOTE" />
     </tag>
   </meta>
-  <url value="http://highmed.org/fhir/StructureDefinition/highmed-task-hello-world" />
+  <url value="http://highmed.org/fhir/StructureDefinition/task-hello-world" />
   <!-- version managed by bpe -->
   <version value="bpe-managed" />
   <name value="helloWorldProcess" />
@@ -17,7 +17,7 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Task" />
-  <baseDefinition value="http://highmed.org/fhir/StructureDefinition/highmed-task-base" />
+  <baseDefinition value="http://highmed.org/fhir/StructureDefinition/task-base" />
   <derivation value="constraint" />
   <differential>
     <element id="Task.instantiatesUri">

--- a/dsf-bpe-process-hello-world/src/test/java/org/highmed/dsf/bpe/start/HelloWorld3MedicTtpExampleStarter.java
+++ b/dsf-bpe-process-hello-world/src/test/java/org/highmed/dsf/bpe/start/HelloWorld3MedicTtpExampleStarter.java
@@ -2,12 +2,12 @@ package org.highmed.dsf.bpe.start;
 
 import static org.highmed.dsf.bpe.ConstantsBase.CODESYSTEM_HIGHMED_BPMN;
 import static org.highmed.dsf.bpe.ConstantsBase.CODESYSTEM_HIGHMED_BPMN_VALUE_MESSAGE_NAME;
-import static org.highmed.dsf.bpe.ConstantsBase.ORGANIZATION_IDENTIFIER_SYSTEM;
+import static org.highmed.dsf.bpe.ConstantsBase.NAMINGSYSTEM_HIGHMED_ORGANIZATION_IDENTIFIER;
+import static org.highmed.dsf.bpe.ConstantsHelloWorld.PROFILE_HIGHMED_TASK_HELLO_WORLD;
+import static org.highmed.dsf.bpe.ConstantsHelloWorld.PROFILE_HIGHMED_TASK_HELLO_WORLD_MESSAGE_NAME;
+import static org.highmed.dsf.bpe.ConstantsHelloWorld.PROFILE_HIGHMED_TASK_HELLO_WORLD_PROCESS_URI_AND_LATEST_VERSION;
 import static org.highmed.dsf.bpe.start.ConstantsExampleStarters.MEDIC_1_FHIR_BASE_URL;
-import static org.highmed.dsf.bpe.start.ConstantsExampleStarters.ORGANIZATION_IDENTIFIER_VALUE_MEDIC_1;
-import static org.highmed.dsf.bpe.ConstantsHelloWorld.HELLO_WORLD_MESSAGE_NAME;
-import static org.highmed.dsf.bpe.ConstantsHelloWorld.HELLO_WORLD_PROCESS_URI_AND_LATEST_VERSION;
-import static org.highmed.dsf.bpe.ConstantsHelloWorld.HELLO_WORLD_TASK_PROFILE;
+import static org.highmed.dsf.bpe.start.ConstantsExampleStarters.NAMINGSYSTEM_HIGHMED_ORGANIZATION_IDENTIFIER_VALUE_MEDIC_1;
 
 import java.util.Date;
 
@@ -32,17 +32,19 @@ public class HelloWorld3MedicTtpExampleStarter
 	private static Task createStartResource()
 	{
 		Task task = new Task();
-		task.getMeta().addProfile(HELLO_WORLD_TASK_PROFILE);
-		task.setInstantiatesUri(HELLO_WORLD_PROCESS_URI_AND_LATEST_VERSION);
+		task.getMeta().addProfile(PROFILE_HIGHMED_TASK_HELLO_WORLD);
+		task.setInstantiatesUri(PROFILE_HIGHMED_TASK_HELLO_WORLD_PROCESS_URI_AND_LATEST_VERSION);
 		task.setStatus(TaskStatus.REQUESTED);
 		task.setIntent(TaskIntent.ORDER);
 		task.setAuthoredOn(new Date());
 		task.getRequester().setType(ResourceType.Organization.name()).getIdentifier()
-				.setSystem(ORGANIZATION_IDENTIFIER_SYSTEM).setValue(ORGANIZATION_IDENTIFIER_VALUE_MEDIC_1);
+				.setSystem(NAMINGSYSTEM_HIGHMED_ORGANIZATION_IDENTIFIER)
+				.setValue(NAMINGSYSTEM_HIGHMED_ORGANIZATION_IDENTIFIER_VALUE_MEDIC_1);
 		task.getRestriction().addRecipient().setType(ResourceType.Organization.name()).getIdentifier()
-				.setSystem(ORGANIZATION_IDENTIFIER_SYSTEM).setValue(ORGANIZATION_IDENTIFIER_VALUE_MEDIC_1);
+				.setSystem(NAMINGSYSTEM_HIGHMED_ORGANIZATION_IDENTIFIER)
+				.setValue(NAMINGSYSTEM_HIGHMED_ORGANIZATION_IDENTIFIER_VALUE_MEDIC_1);
 
-		task.addInput().setValue(new StringType(HELLO_WORLD_MESSAGE_NAME)).getType().addCoding()
+		task.addInput().setValue(new StringType(PROFILE_HIGHMED_TASK_HELLO_WORLD_MESSAGE_NAME)).getType().addCoding()
 				.setSystem(CODESYSTEM_HIGHMED_BPMN).setCode(CODESYSTEM_HIGHMED_BPMN_VALUE_MESSAGE_NAME);
 
 		return task;

--- a/dsf-bpe-process-hello-world/src/test/java/org/highmed/dsf/fhir/profile/TaskProfileTest.java
+++ b/dsf-bpe-process-hello-world/src/test/java/org/highmed/dsf/fhir/profile/TaskProfileTest.java
@@ -2,10 +2,10 @@ package org.highmed.dsf.fhir.profile;
 
 import static org.highmed.dsf.bpe.ConstantsBase.CODESYSTEM_HIGHMED_BPMN;
 import static org.highmed.dsf.bpe.ConstantsBase.CODESYSTEM_HIGHMED_BPMN_VALUE_MESSAGE_NAME;
-import static org.highmed.dsf.bpe.ConstantsBase.ORGANIZATION_IDENTIFIER_SYSTEM;
-import static org.highmed.dsf.bpe.ConstantsHelloWorld.HELLO_WORLD_MESSAGE_NAME;
-import static org.highmed.dsf.bpe.ConstantsHelloWorld.HELLO_WORLD_PROCESS_URI_AND_LATEST_VERSION;
-import static org.highmed.dsf.bpe.ConstantsHelloWorld.HELLO_WORLD_TASK_PROFILE;
+import static org.highmed.dsf.bpe.ConstantsBase.NAMINGSYSTEM_HIGHMED_ORGANIZATION_IDENTIFIER;
+import static org.highmed.dsf.bpe.ConstantsHelloWorld.PROFILE_HIGHMED_TASK_HELLO_WORLD;
+import static org.highmed.dsf.bpe.ConstantsHelloWorld.PROFILE_HIGHMED_TASK_HELLO_WORLD_MESSAGE_NAME;
+import static org.highmed.dsf.bpe.ConstantsHelloWorld.PROFILE_HIGHMED_TASK_HELLO_WORLD_PROCESS_URI_AND_LATEST_VERSION;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -34,38 +34,39 @@ public class TaskProfileTest
 	@ClassRule
 	public static final ValidationSupportRule validationRule = new ValidationSupportRule(
 			Arrays.asList("highmed-task-base-0.4.0.xml", "highmed-task-hello-world.xml"),
-			Arrays.asList("authorization-role-0.4.0.xml", "bpmn-message-0.4.0.xml"),
-			Arrays.asList("authorization-role-0.4.0.xml", "bpmn-message-0.4.0.xml"));
+			Arrays.asList("highmed-authorization-role-0.4.0.xml", "highmed-bpmn-message-0.4.0.xml"),
+			Arrays.asList("highmed-authorization-role-0.4.0.xml", "highmed-bpmn-message-0.4.0.xml"));
 
 	private ResourceValidator resourceValidator = new ResourceValidatorImpl(validationRule.getFhirContext(),
 			validationRule.getValidationSupport());
 
 	@Test
-	public void testTaskHelloWorldValid() throws Exception
+	public void testTaskHelloWorldValid()
 	{
 		Task task = createValidTaskHelloWorld();
 
 		ValidationResult result = resourceValidator.validate(task);
 		ValidationSupportRule.logValidationMessages(logger, result);
 
-		assertEquals(0, result.getMessages().stream().filter(m -> ResultSeverityEnum.ERROR.equals(m.getSeverity())
-				|| ResultSeverityEnum.FATAL.equals(m.getSeverity())).count());
+		assertEquals(0, result.getMessages().stream()
+				.filter(m -> ResultSeverityEnum.ERROR.equals(m.getSeverity()) || ResultSeverityEnum.FATAL
+						.equals(m.getSeverity())).count());
 	}
 
 	private Task createValidTaskHelloWorld()
 	{
 		Task task = new Task();
-		task.getMeta().addProfile(HELLO_WORLD_TASK_PROFILE);
-		task.setInstantiatesUri(HELLO_WORLD_PROCESS_URI_AND_LATEST_VERSION);
+		task.getMeta().addProfile(PROFILE_HIGHMED_TASK_HELLO_WORLD);
+		task.setInstantiatesUri(PROFILE_HIGHMED_TASK_HELLO_WORLD_PROCESS_URI_AND_LATEST_VERSION);
 		task.setStatus(TaskStatus.REQUESTED);
 		task.setIntent(TaskIntent.ORDER);
 		task.setAuthoredOn(new Date());
 		task.getRequester().setType(ResourceType.Organization.name()).getIdentifier()
-				.setSystem(ORGANIZATION_IDENTIFIER_SYSTEM).setValue("MeDIC 1");
+				.setSystem(NAMINGSYSTEM_HIGHMED_ORGANIZATION_IDENTIFIER).setValue("MeDIC 1");
 		task.getRestriction().addRecipient().setType(ResourceType.Organization.name()).getIdentifier()
-				.setSystem(ORGANIZATION_IDENTIFIER_SYSTEM).setValue("MeDIC 1");
+				.setSystem(NAMINGSYSTEM_HIGHMED_ORGANIZATION_IDENTIFIER).setValue("MeDIC 1");
 
-		task.addInput().setValue(new StringType(HELLO_WORLD_MESSAGE_NAME)).getType().addCoding()
+		task.addInput().setValue(new StringType(PROFILE_HIGHMED_TASK_HELLO_WORLD_MESSAGE_NAME)).getType().addCoding()
 				.setSystem(CODESYSTEM_HIGHMED_BPMN).setCode(CODESYSTEM_HIGHMED_BPMN_VALUE_MESSAGE_NAME);
 
 		return task;


### PR DESCRIPTION
Refactoring of constant namings and fhir profiles:

- Removes the term 'simple' from the naming in the feasibility process
- In StructureDefinitions of type Extension, the term 'extension' was added to the URL
- In StructureDefinitions where 'highmed.org' is the base-URL, other occurrences of the term 'highmed' were removed
- Filenames of FHIR profiles are changed to include the organisation of the base-URL, e.g. 'highmed-requestFeasibility.xml'
- BPMN variabel constants start now with the term 'BPMN_EXECUTION_VARIABLE_'
- FHIR related constants start now with the type the resource type followed by the organisation of the base-url, e.g 'NAMINGSYSTEM_HIGHMED_ ... '